### PR TITLE
Add upload function for 3dat workload

### DIFF
--- a/portal/backend/apps/local/api/urls.py
+++ b/portal/backend/apps/local/api/urls.py
@@ -23,6 +23,9 @@ urlpatterns = [
         "provision/",
         ProvisionAPIView.as_view()),
     path(
+        "upload_video_check/",
+        UploadVideoCheck.as_view()),
+    path(
         "schedule_check/",
         ScheduleCheck.as_view()),
     path(

--- a/portal/backend/taas/settings.py
+++ b/portal/backend/taas/settings.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join(BASE_DIR, 'backend/extra_apps'))
 SECRET_KEY = '1^f6s%w(0^3#@2%9e+v5q--5umw)2hy1rz+5sl149or2yspy@r'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
@@ -178,8 +178,8 @@ WEBPACK_LOADER = {
 LOG_FILE_DIR = os.path.join(BASE_DIR, 'backend/logs/')
 
 # Media
-MEDIA_URL = "/media/local/logs/"
-MEDIA_ROOT = "workspace/local/logs/"
+MEDIA_URL = "/local/media/"
+MEDIA_ROOT = "/backend/workspace/local/media"
 IMPORT_EXPORT_USE_TRANSACTIONS = True
 
 # django-crispy-forms

--- a/portal/backend/taas/settings_dev.py
+++ b/portal/backend/taas/settings_dev.py
@@ -1,3 +1,3 @@
 from taas.settings import *
 
-DEBUG = False
+DEBUG = True

--- a/portal/backend/taas/settings_dev_docker.py
+++ b/portal/backend/taas/settings_dev_docker.py
@@ -1,6 +1,6 @@
 from taas.settings import *
 
-DEBUG = False
+DEBUG = True
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Add upload function in 'Workload Args' of frontend, mainly support for the 3DHuman-Pose-Estimation workload.

This upload function only display when 3DHuman-Pose-Estimation workload selected.
<img width="458" alt="image" src="https://user-images.githubusercontent.com/25050767/221462867-21632bb7-24e4-49d1-bf82-ee20244bff60.png">

After uploaded it will be renamed and stored in the `backend/workspace/media` folder, and generate video download info into Workload Parameters (only available when video files exist). 
